### PR TITLE
Adding gear to run it in K8s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang
+
+RUN  apt-get update && apt-get install -y curl
+
+ADD . /go/src/bad-server
+
+CMD go run /go/src/bad-server/main.go
+ 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,39 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: bad-server
+  namespace: ingress-benchmark 
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: bad-server
+    spec:
+      containers:
+       - image: registry.example.com:6666/bad-server:latest
+         name: bad-server
+         imagePullPolicy: IfNotPresent 
+         command: ["go"]
+         args: ["run", "/go/src/bad-server/main.go"]
+         ports:
+         - containerPort: 7865
+           protocol: TCP
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: bad-server
+  namespace: ingress-benchmark
+spec:
+  rules:
+  - host: bad.internal.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: bad-server
+          servicePort: 7865 
+        path: /
+status:
+  loadBalancer: {}

--- a/manifest.yml
+++ b/manifest.yml
@@ -21,6 +21,22 @@ spec:
          - containerPort: 7865
            protocol: TCP
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bad-server
+  namespace: ingress-benchmark
+spec:
+  selector:
+    app: bad-server
+  ports:
+  - name: http
+    port: 7865
+    protocol: TCP
+    targetport: 7865
+  type: ClusterIP
+
+---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:


### PR DESCRIPTION
Tested : 
```
$ time curl -H'Host: bad.internal.example.com' -v http://18.1.1.1/
* Trying 18.1.1.1...
* TCP_NODELAY set
* Connected to 18.1.1.1 (18.1.1.1) port 80 (#0)
> GET / HTTP/1.1
> Host: bad.internal.unity3d.com
> User-Agent: curl/7.52.1
> Accept: */*
>
< HTTP/1.1 200 OK
< Server: nginx
< Date: Thu, 02 Nov 2017 19:55:55 GMT
< Content-Type: text/plain; charset=utf-8
< Content-Length: 0
< Connection: keep-alive
<
* Curl_http_done: called premature == 0
* Connection #0 to host 18.1.1.1 left intact

real	0m0.200s
user	0m0.024s
sys	0m0.004s
```

Totally open to comments on styling, naming, etc.