### PR TITLE
Add JSON generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ header in a request. Exceptions to this include:
 
   * X-Response-Code-Histogram
   * X-Return-Header
+  * X-Random-Json
   
 Headers
 -------
@@ -45,6 +46,26 @@ X-Random-Delays: randomly delay sending chunks of data
 
   * X-Random-Delays: 100 => chunks of data will be sent with up to 100ms delays sprinkled in
   * X-Random-Delays: 10ns=70.0;100ms => chunks of data will be sent with up to 10ns delays 70% of the time, and up to 100ms for 30% of the time
+  
+X-Random-Json: send random but structured JSON to the client to simulate unexpectedly large payloads
+
+  * X-Random-Json: response_template=[string]:100 => sends an array of 100 strings
+  * X-Random-Json: response_template=[returnObject]:100;returnObject=id/int,name/string => send 100 objects that have a numeric ID field and a string name field
+  * X-Random-Json: response_template=[returnObject]:100;returnObject=author/authorObject;authorObject=id/int,name/string => send 100 records where each one will have an author key that will in turn be an object with an id and name
+  * X-Random-Json: response_template=titlesContainer;titlesContainer=titles/[string]:100 => return an object that contains a field named titles that is 100 random strings
+  
+More on X-Random-Json
+---------------------
+Here are the primitive data types you can use for a field:
+
+  * string
+  * int
+  * float
+  * bool
+  * increment - a numeric field that increases in each record
+  * <object name> - another object defined within the same header
+  
+Each of these can have [] placed around them to create an array of that type. Arrays are 10,000 items unless you specify a length with ":N" after the array. The "root" item must be identified with "response_template="
   
 Complex Examples
 ----------------
@@ -80,7 +101,8 @@ generators in your header, they will be processed in this order (from `general.g
 
     1. X-Request-Body-As-Response
     2. X-Generate-Random
-    3. empty string
+    3. X-Random-Json
+    4. empty string
   
   
   

--- a/badness/general_test.go
+++ b/badness/general_test.go
@@ -20,3 +20,33 @@ func TestHeaderAbsent(test *testing.T) {
 		test.Fatal("requestHasHeader should be false for X-Response-Code")
 	}
 }
+
+type normalizeJsonTemplateTest struct {
+	inputs        []string
+	output        string
+	errorExpected bool
+}
+
+func TestNormalizeJsonTemplate(test *testing.T) {
+	tests := []normalizeJsonTemplateTest{
+		normalizeJsonTemplateTest{[]string{"response_template=bookshelf;bookshelf=books/[book]:10;;book=title/string,pages/int,isbn/string"}, "bookshelf;bookshelf=books/[book]:10;;book=title/string,pages/int,isbn/string", false},
+		normalizeJsonTemplateTest{[]string{"bookshelf;bookshelf=books/[book]:10;;book=title/string,pages/int,isbn/string"}, "", true},
+		normalizeJsonTemplateTest{[]string{"response_template=bookshelf;bookshelf=books/[book]:10", "book=title/string,pages/int,isbn/string"}, "bookshelf;bookshelf=books/[book]:10;book=title/string,pages/int,isbn/string", false},
+		normalizeJsonTemplateTest{[]string{"bookshelf;bookshelf=books/[book]:10", "book=title/string,pages/int,isbn/string"}, "", true},
+	}
+	for _, templateTest := range tests {
+		actual, err := normalizeJsonTemplateParameters(templateTest.inputs)
+
+		if err != nil && !templateTest.errorExpected {
+			test.Fatalf("Unexpected error parsing %v: %v", templateTest.inputs, err)
+		}
+
+		if err == nil && templateTest.errorExpected {
+			test.Fatalf("Expected an error for %v but did not get one", templateTest.inputs)
+		}
+
+		if templateTest.output != actual {
+			test.Errorf("Expected %s for %v, but got %s", templateTest.output, templateTest.inputs, actual)
+		}
+	}
+}

--- a/badness/json_generator.go
+++ b/badness/json_generator.go
@@ -1,0 +1,342 @@
+package badness
+
+import (
+	"fmt"
+	"io"
+	"math/rand"
+	"strconv"
+
+	"bad-server/badness/json_template"
+)
+
+const RandomJson = "X-Random-Json"
+
+var stringCharacters = [52]byte{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+	'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'}
+
+type jsonElementGenerator interface {
+	generate(writer io.Writer) (int, error)
+}
+
+// createJsonTemplate takes an input string and parses it with the json_template tools.
+// The resulting DataDeclaration set is converted to a nested tree of json generators as needed.
+// It is assumed that the first data definition in the input string is the root of the json.
+// Calling methods will need to make sure of that state
+func createJsonTemplate(input string) (jsonElementGenerator, error) {
+	parser := json_template.NewParserWithString(input)
+	template, err := parser.ParseTemplate()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(template.Declarations) == 0 {
+		return nil, fmt.Errorf("No json template definitions found")
+	}
+
+	return generatorFromDataDeclaration(template, template.Declarations[0])
+}
+
+// generatorFromDataDeclaration takes a json_template DataDeclaration and converts it
+// to the appropriate json generator.
+func generatorFromDataDeclaration(template *json_template.Template, declaration json_template.DataDeclaration) (jsonElementGenerator, error) {
+	switch declaration.(type) {
+	case json_template.PrimitiveDataType:
+		return primitiveGeneratorFromDataType(declaration.(json_template.PrimitiveDataType))
+	case json_template.ArrayDataType:
+		return arrayGeneratorFromDataType(template, declaration.(json_template.ArrayDataType))
+	case json_template.KeyValueDataType:
+		return keyValueGeneratorFromDataType(template, declaration.(json_template.KeyValueDataType))
+	case json_template.KeyNameDataType:
+		// ensure parser has an object of the given type
+		key := declaration.(json_template.KeyNameDataType).Literal
+		object, found := template.CustomTypes[key]
+		if !found {
+			return nil, fmt.Errorf("Unknown data type: %s", key)
+		}
+		return objectGeneratorFromDataType(template, object.(json_template.ObjectDataType))
+	default:
+		return nil, fmt.Errorf("Unknown type: %v", declaration)
+	}
+}
+
+func objectGeneratorFromDataType(template *json_template.Template, object json_template.ObjectDataType) (jsonElementGenerator, error) {
+	keyValues := make([]keyValueGenerator, 0, len(object.Members))
+	for _, keyValueData := range object.Members {
+		generator, err := keyValueGeneratorFromDataType(template, keyValueData)
+		if err != nil {
+			return nil, err
+		}
+		keyValues = append(keyValues, generator.(keyValueGenerator))
+	}
+	return newObjectGenerator(keyValues), nil
+}
+
+func keyValueGeneratorFromDataType(template *json_template.Template, declaration json_template.KeyValueDataType) (jsonElementGenerator, error) {
+	valueGenerator, err := generatorFromDataDeclaration(template, declaration.Value)
+	if err != nil {
+		return nil, err
+	}
+	return newKeyValueGenerator(declaration.Key, valueGenerator), nil
+}
+
+func arrayGeneratorFromDataType(template *json_template.Template, declaration json_template.ArrayDataType) (jsonElementGenerator, error) {
+	nestedGenerator, err := generatorFromDataDeclaration(template, declaration.NestedType)
+	if err != nil {
+		return nil, err
+	}
+	return newArrayGenerator(declaration.Length, nestedGenerator), nil
+}
+
+func primitiveGeneratorFromDataType(declaration json_template.PrimitiveDataType) (jsonElementGenerator, error) {
+	switch declaration.TokenLiteral() {
+	case "string":
+		return newRandomStringGenerator(), nil
+	case "int":
+		return newIntGenerator(10000), nil
+	case "bool":
+		return newBooleanGenerator(), nil
+	case "increment":
+		return newIncrementGenerator(1), nil
+	default:
+		return nil, fmt.Errorf("Unknown primitive type: %s", declaration.TokenLiteral())
+	}
+}
+
+// writeGeneratorsInList concatenates the output of the generators into the writer with the given character
+func writeGeneratorsInList(generators []jsonElementGenerator, writer io.Writer, joinString string) (int, error) {
+	bytesTotal := 0
+	delimiter := []byte(joinString)
+	for index, generator := range generators {
+		bytes, err := generator.generate(writer)
+		bytesTotal += bytes
+		if err != nil {
+			return bytesTotal, err
+		}
+
+		if index != len(generators)-1 {
+			bytes, err = writer.Write(delimiter)
+			bytesTotal += bytes
+			if err != nil {
+				return bytesTotal, err
+			}
+		}
+	}
+	return bytesTotal, nil
+}
+
+func newErrorGenerator(message string) jsonElementGenerator {
+	keyValue := newKeyValueGenerator("error", newFixedStringGenerator(message))
+
+	return newObjectGenerator([]keyValueGenerator{keyValue.(keyValueGenerator)})
+}
+
+// useful for generating empty arrays. Does nothing to the writer
+type noItemGenerator struct{}
+
+func (generator noItemGenerator) generate(writer io.Writer) (int, error) {
+	return 0, nil
+}
+func newNoItemGenerator() jsonElementGenerator {
+	return noItemGenerator{}
+}
+
+// ---   Generate random strings of a given length --
+var quote = []byte{'"'}
+
+type randomStringGenerator struct {
+	length int
+}
+
+func (generator randomStringGenerator) generate(writer io.Writer) (int, error) {
+	buffer := make([]byte, generator.length+2)
+	buffer[0] = '"'
+
+	for current := 0; current < generator.length; current++ {
+		randomIndex := rand.Intn(len(stringCharacters))
+		buffer[current+1] = stringCharacters[randomIndex]
+	}
+	// terminal quote is the full length - 1
+	buffer[generator.length+2-1] = '"'
+
+	bytesWritten, err := writer.Write(buffer[0 : generator.length+2])
+	return bytesWritten, err
+}
+
+func newRandomStringGenerator() jsonElementGenerator {
+	return randomStringGenerator{30}
+}
+
+// ---- Generate constant strings -----
+type fixedStringGenerator struct {
+	fixedString string
+}
+
+func (generator fixedStringGenerator) generate(writer io.Writer) (int, error) {
+	bytesTotal, err := writer.Write(quote)
+
+	if err != nil {
+		return bytesTotal, err
+	}
+	bytes, err := writer.Write([]byte(generator.fixedString))
+	bytesTotal += bytes
+	if err != nil {
+		return bytesTotal, err
+	}
+	bytes, err = writer.Write(quote)
+	bytesTotal += bytes
+	return bytesTotal, err
+}
+
+func newFixedStringGenerator(fixedString string) jsonElementGenerator {
+	return fixedStringGenerator{fixedString}
+}
+
+// --------- bool generator
+type booleanGenerator struct{}
+
+func (generator booleanGenerator) generate(writer io.Writer) (int, error) {
+	// generates true/false randomly
+	boolean := "true"
+	if rand.Float32() > 0.5 {
+		boolean = "false"
+	}
+	return writer.Write([]byte(boolean))
+}
+
+func newBooleanGenerator() jsonElementGenerator {
+	return &booleanGenerator{}
+}
+
+// --------- int generator. generates a random number up to the max
+type intGenerator struct {
+	maxNumber int
+}
+
+func (generator intGenerator) generate(writer io.Writer) (int, error) {
+	intToWrite := rand.Intn(generator.maxNumber)
+	intString := strconv.Itoa(intToWrite)
+	return writer.Write([]byte(intString))
+}
+
+func newIntGenerator(maxNum int) jsonElementGenerator {
+	return intGenerator{maxNum}
+}
+
+// ---------- increment generator. starting at a value, counts up
+type incrementGenerator struct {
+	current int
+}
+
+func (generator *incrementGenerator) generate(writer io.Writer) (int, error) {
+	intString := strconv.Itoa(generator.current)
+	bytesWritten, err := writer.Write([]byte(intString))
+	// no matter what, increment the counter. Even if there's an error, it's more expected
+	// that the number would go up versus staying the same.
+	generator.current++
+	return bytesWritten, err
+}
+
+func newIncrementGenerator(start int) jsonElementGenerator {
+	return &incrementGenerator{start}
+}
+
+// ---- Array generator --------
+var leftBracket = []byte{'['}
+var rightBracket = []byte{']'}
+var comma = []byte{','}
+
+type arrayGenerator struct {
+	length            int
+	generatorToRepeat jsonElementGenerator
+}
+
+func (generator arrayGenerator) generate(writer io.Writer) (int, error) {
+	bytesTotal, err := writer.Write(leftBracket)
+	if err != nil {
+		return bytesTotal, err
+	}
+
+	// make a list of generators to conform to writeGenerators spec
+	generators := make([]jsonElementGenerator, 0)
+	for index := 0; index < generator.length; index++ {
+		generators = append(generators, generator.generatorToRepeat)
+	}
+
+	bytes, err := writeGeneratorsInList(generators, writer, ",")
+	bytesTotal += bytes
+	if err != nil {
+		return bytesTotal, err
+	}
+
+	bytes, err = writer.Write(rightBracket)
+	bytesTotal += bytes
+	return bytesTotal, err
+}
+
+func newArrayGenerator(length int, generator jsonElementGenerator) jsonElementGenerator {
+	return arrayGenerator{length, generator}
+}
+
+// -------------------- keyvalue generator -------------------
+type keyValueGenerator struct {
+	key   fixedStringGenerator
+	value jsonElementGenerator
+}
+
+var colon = []byte{':'}
+
+func (generator keyValueGenerator) generate(writer io.Writer) (int, error) {
+	bytesTotal, err := generator.key.generate(writer)
+	if err != nil {
+		return bytesTotal, err
+	}
+
+	bytes, err := writer.Write(colon)
+	bytesTotal += bytes
+	if err != nil {
+		return bytesTotal, err
+	}
+
+	bytes, err = generator.value.generate(writer)
+	bytesTotal += bytes
+	return bytesTotal, err
+}
+
+func newKeyValueGenerator(key string, value jsonElementGenerator) jsonElementGenerator {
+	return keyValueGenerator{newFixedStringGenerator(key).(fixedStringGenerator), value}
+}
+
+// -------------- object generator
+var leftBrace = []byte{'{'}
+var rightBrace = []byte{'}'}
+
+type objectGenerator struct {
+	generators []keyValueGenerator
+}
+
+func (generator objectGenerator) generate(writer io.Writer) (int, error) {
+	bytesTotal, err := writer.Write(leftBrace)
+	if err != nil {
+		return bytesTotal, err
+	}
+
+	// convert generator list  to jsonElementGenerator
+	generators := make([]jsonElementGenerator, 0)
+	for _, generator := range generator.generators {
+		generators = append(generators, jsonElementGenerator(generator))
+	}
+
+	bytes, err := writeGeneratorsInList(generators, writer, ",")
+	bytesTotal += bytes
+	if err != nil {
+		return bytesTotal, err
+	}
+
+	bytes, err = writer.Write(rightBrace)
+	bytesTotal += bytes
+	return bytesTotal, err
+}
+
+func newObjectGenerator(generators []keyValueGenerator) jsonElementGenerator {
+	return objectGenerator{generators}
+}

--- a/badness/json_generator_test.go
+++ b/badness/json_generator_test.go
@@ -1,0 +1,157 @@
+package badness
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"testing"
+)
+
+// expectations when there are not errors midstream
+type jsonElementExpectation struct {
+	generator     jsonElementGenerator
+	expectedRegex string
+}
+
+func TestJsonElementGeneration(test *testing.T) {
+	expects := []jsonElementExpectation{
+		jsonElementExpectation{newFixedStringGenerator("test"), "^\"test\"$"},
+		jsonElementExpectation{newArrayGenerator(0, newNoItemGenerator()), "\\[\\]"},
+		jsonElementExpectation{newKeyValueGenerator("index", newFixedStringGenerator("value")), "\"index\":\"value\""},
+		jsonElementExpectation{newArrayGenerator(1, newFixedStringGenerator("testing")), "\\[\"testing\"\\]"},
+		jsonElementExpectation{newArrayGenerator(2, newFixedStringGenerator("hello")), "[\"hello\",\"hello\"]"},
+		jsonElementExpectation{newBooleanGenerator(), "true|false"},
+		jsonElementExpectation{newRandomStringGenerator(), "\"[a-zA-Z]{30}\""},
+		jsonElementExpectation{newIntGenerator(10000), "[0-9]+"},
+		jsonElementExpectation{newArrayGenerator(2, newIncrementGenerator(1)), "\\[1,2\\]"},
+		jsonElementExpectation{newObjectGenerator([]keyValueGenerator{newKeyValueGenerator("key1", newIntGenerator(100)).(keyValueGenerator), newKeyValueGenerator("key2", newFixedStringGenerator("value")).(keyValueGenerator)}), "\\{\"key1\":[0-9]+,\"key2\":\"value\"}"},
+		jsonElementExpectation{newErrorGenerator("no-error"), "\\{\"error\":\"no-error\"\\}"},
+	}
+
+	for index, expect := range expects {
+		generatedString := generatedString(expect.generator)
+		match, err := regexp.Match(expect.expectedRegex, []byte(generatedString))
+		if err != nil {
+			test.Fatalf("Regexp error: %v", err)
+		}
+
+		if !match {
+			test.Errorf("Test %d: Expected %s but got %s", index, expect.expectedRegex, generatedString)
+		}
+	}
+}
+
+// a special writer that returns an error after the specified number
+// of bytes has been reached
+type interruptingWriter struct {
+	interruptAt int
+	totalBytes  int
+	bytes.Buffer
+}
+
+func (writer *interruptingWriter) Write(bytes []byte) (int, error) {
+	// we need to track the bytes for just this write,
+	// as that's what we need to return to the client
+	bytesThisWrite := 0
+	for _, toWrite := range bytes {
+		bytesWritten, _ := writer.Buffer.Write([]byte{toWrite})
+		bytesThisWrite += bytesWritten
+		writer.totalBytes += bytesWritten
+
+		if writer.totalBytes == writer.interruptAt {
+			return bytesThisWrite, fmt.Errorf("Stopping at %d bytes", writer.totalBytes)
+		}
+	}
+	return bytesThisWrite, nil
+}
+
+type jsonWithInterruptExpectation struct {
+	stopAt    int
+	generator jsonElementGenerator
+	// the regex of the string you'd expect from the interrupt
+	expectedRegex string
+}
+
+// TestInterruptedJson verifies that jsonGenerators return appropriate bytesRead and errors
+// in the face of underlying exceptions
+func TestInterruptedJson(test *testing.T) {
+	expects := []jsonWithInterruptExpectation{
+		jsonWithInterruptExpectation{1, newFixedStringGenerator("test"), "^\"$"},
+		jsonWithInterruptExpectation{3, newFixedStringGenerator("test"), "^\"te$"},
+		jsonWithInterruptExpectation{6, newFixedStringGenerator("test"), "^\"test\"$"},
+		jsonWithInterruptExpectation{1, newRandomStringGenerator(), "^\"$"},
+		jsonWithInterruptExpectation{5, newRandomStringGenerator(), "^\"[a-zA-Z]{4}$"},
+		jsonWithInterruptExpectation{32, newRandomStringGenerator(), "^\"[a-zA-Z]{30}\"$"},
+		jsonWithInterruptExpectation{1, newBooleanGenerator(), "^(t|f)$"},
+		jsonWithInterruptExpectation{4, newBooleanGenerator(), "^(true|fals)$"},
+		jsonWithInterruptExpectation{1, newIntGenerator(1000000), "^[0-9]+$"},
+		jsonWithInterruptExpectation{1, newArrayGenerator(2, newFixedStringGenerator("test")), "^\\[$"},
+		jsonWithInterruptExpectation{8, newArrayGenerator(2, newFixedStringGenerator("test")), "^\\[\"test\","},
+		jsonWithInterruptExpectation{10, newArrayGenerator(2, newFixedStringGenerator("test")), "^\\[\"test\",\"t$"},
+		jsonWithInterruptExpectation{1, newKeyValueGenerator("key", newFixedStringGenerator("value")), "^\"$"},
+		jsonWithInterruptExpectation{5, newKeyValueGenerator("key", newFixedStringGenerator("value")), "^\"key\"$"},
+		jsonWithInterruptExpectation{6, newKeyValueGenerator("key", newFixedStringGenerator("value")), "^\"key\":$"},
+		jsonWithInterruptExpectation{13, newKeyValueGenerator("key", newFixedStringGenerator("value")), "^\"key\":\"value\"$"},
+		jsonWithInterruptExpectation{1, newObjectGenerator([]keyValueGenerator{newKeyValueGenerator("test", newFixedStringGenerator("value")).(keyValueGenerator)}), "\\{$"},
+		jsonWithInterruptExpectation{7, newObjectGenerator([]keyValueGenerator{newKeyValueGenerator("test", newFixedStringGenerator("value")).(keyValueGenerator)}), "\\{\"test\"$"},
+		jsonWithInterruptExpectation{8, newObjectGenerator([]keyValueGenerator{newKeyValueGenerator("test", newFixedStringGenerator("value")).(keyValueGenerator)}), "\\{\"test\":$"},
+		jsonWithInterruptExpectation{15, newObjectGenerator([]keyValueGenerator{newKeyValueGenerator("test", newFixedStringGenerator("value")).(keyValueGenerator)}), "\\{\"test\":\"value\"$"},
+		jsonWithInterruptExpectation{16, newObjectGenerator([]keyValueGenerator{newKeyValueGenerator("test", newFixedStringGenerator("value")).(keyValueGenerator)}), "\\{\"test\":\"value\"\\}$"},
+	}
+
+	for index, expect := range expects {
+		writer := new(interruptingWriter)
+		writer.interruptAt = expect.stopAt
+
+		written, err := expect.generator.generate(writer)
+		if err == nil {
+			test.Errorf("Test case %d: Expected an error but got nil", index)
+		}
+
+		if written != expect.stopAt {
+			test.Errorf("Test case %d: Expected %d bytes written but got %d", index, expect.stopAt, written)
+		}
+
+		generatedString := string(writer.Bytes()[0:written])
+		match, err := regexp.Match(expect.expectedRegex, []byte(generatedString))
+		if err != nil {
+			test.Fatalf("Regexp error: %v", err)
+		}
+
+		if !match {
+			test.Errorf("Test case %d: Expected %s but got %s", index, expect.expectedRegex, generatedString)
+		}
+
+	}
+}
+
+func TestTemplateDefinitionToJson(test *testing.T) {
+	// template language strings to expected json regex
+	tests := map[string]string{
+		"string":                 "^\"[a-zA-Z]{30}\"$",
+		"int":                    "^[0-9]+$",
+		"bool":                   "^(true|false)$",
+		"[string]:1":             "^\\[\"[a-zA-Z]{30}\"\\]",
+		"test;test=title/string": "^{\"title\":\"[a-zA-Z]{30}\"}$",
+	}
+
+	for input, expected := range tests {
+		generator, err := createJsonTemplate(input)
+		if err != nil {
+			test.Fatalf("Parsing input string failed: %v", err)
+		}
+		generated := generatedString(generator)
+		regex := regexp.MustCompile(expected)
+
+		if !regex.Match([]byte(generated)) {
+			test.Errorf("Expected input %s to match regex %s, but was %s", input, expected, generated)
+		}
+	}
+}
+
+// Refactored method for generating a string from the generator's output
+func generatedString(generator jsonElementGenerator) string {
+	var buffer bytes.Buffer
+	written, _ := generator.generate(&buffer)
+	return string(buffer.Bytes()[0:written])
+}

--- a/badness/json_template/ast.go
+++ b/badness/json_template/ast.go
@@ -1,0 +1,89 @@
+package json_template
+
+import (
+	"fmt"
+)
+
+// ast for json_template code. A template is defined by a series of
+// data declarations.
+type DataDeclaration interface {
+	TokenLiteral() string
+}
+
+type Template struct {
+	Declarations []DataDeclaration
+	CustomTypes  map[string]DataDeclaration
+}
+
+func (template *Template) TokenLiteral() string {
+	if len(template.Declarations) > 0 {
+		return template.Declarations[0].TokenLiteral()
+	} else {
+		return ""
+	}
+}
+
+func (template *Template) addDataDeclaration(def DataDeclaration) {
+	template.Declarations = append(template.Declarations, def)
+}
+
+func (template *Template) addCustomType(name string, definition DataDeclaration) {
+	template.CustomTypes[name] = definition
+}
+
+type PrimitiveDataType struct {
+	DataDeclaration
+	Literal string
+}
+
+func (primitive PrimitiveDataType) TokenLiteral() string {
+	return primitive.Literal
+}
+
+type KeyNameDataType struct {
+	DataDeclaration
+	Literal string
+}
+
+func (keyName KeyNameDataType) TokenLiteral() string {
+	return keyName.Literal
+}
+
+type ArrayDataType struct {
+	DataDeclaration
+	NestedType DataDeclaration
+	Length     int
+}
+
+func (array ArrayDataType) TokenLiteral() string {
+	return fmt.Sprintf("[%s]:%d", array.NestedType.TokenLiteral(), array.Length)
+}
+
+type KeyValueDataType struct {
+	DataDeclaration
+	Key   string
+	Value DataDeclaration
+}
+
+func (keyValue KeyValueDataType) TokenLiteral() string {
+	return fmt.Sprintf("%s: %s", keyValue.Key, keyValue.Value.TokenLiteral())
+}
+
+type ObjectDataType struct {
+	DataDeclaration
+	Members []KeyValueDataType
+}
+
+func (object ObjectDataType) TokenLiteral() string {
+	returnString := "{"
+
+	for index, member := range object.Members {
+		returnString += member.TokenLiteral()
+		if index != len(object.Members)-1 {
+			returnString += ", "
+		}
+	}
+
+	returnString += "}"
+	return returnString
+}

--- a/badness/json_template/lexer.go
+++ b/badness/json_template/lexer.go
@@ -1,0 +1,97 @@
+package json_template
+
+type Lexer struct {
+	input        string
+	position     int  // current position in input
+	readPosition int  // next read position
+	ch           byte // current char
+}
+
+func newLexer(input string) *Lexer {
+	lexer := &Lexer{input: input}
+	lexer.readChar()
+	return lexer
+}
+
+func (lexer *Lexer) readChar() {
+	if lexer.readPosition >= len(lexer.input) {
+		lexer.ch = 0
+	} else {
+		lexer.ch = lexer.input[lexer.readPosition]
+	}
+	lexer.position = lexer.readPosition
+	lexer.readPosition += 1
+}
+
+func (lexer *Lexer) NextToken() Token {
+	var token Token
+
+	switch lexer.ch {
+	case 0:
+		token = newToken(EOF, 0)
+	case '=':
+		token = newToken(EQUAL, lexer.ch)
+	case ';':
+		token = newToken(SEMICOLON, lexer.ch)
+	case '/':
+		token = newToken(SLASH, lexer.ch)
+	case '[':
+		token = newToken(LEFT_BRACKET, lexer.ch)
+	case ']':
+		token = newToken(RIGHT_BRACKET, lexer.ch)
+	case ':':
+		token = newToken(COLON, lexer.ch)
+	case ',':
+		token = newToken(COMMA, lexer.ch)
+	default:
+		if isLetter(lexer.ch) {
+			fullString := lexer.readString()
+			token.Type = stringToToken(fullString)
+			token.Literal = fullString
+			return token
+		} else if isDigit(lexer.ch) {
+			number := lexer.readNumber()
+			token.Type = NUMBER
+			token.Literal = string(number)
+			return token
+		} else {
+			token = newToken(ILLEGAL, lexer.ch)
+		}
+	}
+
+	lexer.readChar()
+	return token
+}
+
+func (lexer *Lexer) readString() string {
+	position := lexer.position
+	for isLetter(lexer.ch) {
+		lexer.readChar()
+	}
+	return lexer.input[position:lexer.position]
+}
+
+func (lexer *Lexer) readNumber() string {
+	position := lexer.position
+	for isDigit(lexer.ch) {
+		lexer.readChar()
+	}
+	return lexer.input[position:lexer.position]
+}
+
+func isLetter(char byte) bool {
+	return isCharBetween(char, 'a', 'z') || isCharBetween(char, 'A', 'Z') || char == '-' || char == '_'
+}
+
+func isDigit(char byte) bool {
+	return isCharBetween(char, '0', '9')
+}
+
+// isCharBetween determines if char is between lower and higher inclusively
+func isCharBetween(char byte, lower byte, higher byte) bool {
+	return lower <= char && char <= higher
+}
+
+func newToken(tokenType TokenType, ch byte) Token {
+	return Token{tokenType, string(ch)}
+}

--- a/badness/json_template/lexer_test.go
+++ b/badness/json_template/lexer_test.go
@@ -1,0 +1,139 @@
+package json_template
+
+import (
+	"testing"
+)
+
+type tokenExpect struct {
+	expectedType    TokenType
+	expectedLiteral string
+}
+
+func TestNextToken(test *testing.T) {
+	input := "=:,/[];string;bookcase;increment;int;bool;1234"
+
+	expects := []tokenExpect{
+		{EQUAL, "="},
+		{COLON, ":"},
+		{COMMA, ","},
+		{SLASH, "/"},
+		{LEFT_BRACKET, "["},
+		{RIGHT_BRACKET, "]"},
+		{SEMICOLON, ";"},
+		{STRING_DATA_TYPE, "string"},
+		{SEMICOLON, ";"},
+		{KEY_NAME, "bookcase"},
+		{SEMICOLON, ";"},
+		{INCREMENT_DATA_TYPE, "increment"},
+		{SEMICOLON, ";"},
+		{INT_DATA_TYPE, "int"},
+		{SEMICOLON, ";"},
+		{BOOL_DATA_TYPE, "bool"},
+		{SEMICOLON, ";"},
+		{NUMBER, "1234"},
+	}
+	lexer := newLexer(input)
+
+	for index, expect := range expects {
+		token := lexer.NextToken()
+
+		if token.Type != expect.expectedType {
+			test.Errorf("Test case %d: Expected %s but got %s", index, expect.expectedType, token.Type)
+		}
+
+		if token.Literal != expect.expectedLiteral {
+			test.Errorf("Test case %d: Expected %s but got %s", index, expect.expectedLiteral, token.Literal)
+		}
+	}
+}
+
+type isCharExpect struct {
+	charTest byte
+	lower    byte
+	higher   byte
+	result   bool
+}
+
+func TestIsCharBetween(test *testing.T) {
+	expects := []isCharExpect{
+		isCharExpect{'q', 'a', 'z', true},
+		isCharExpect{'a', 'a', 'z', true},
+		isCharExpect{'z', 'a', 'z', true},
+		isCharExpect{'A', 'a', 'z', false},
+	}
+
+	for index, expect := range expects {
+		metExpectation := isCharBetween(expect.charTest, expect.lower, expect.higher)
+		if metExpectation != expect.result {
+			test.Errorf("Test %d: Expected %v but got %v", index, expect.result, metExpectation)
+		}
+	}
+}
+
+func TestIsLetter(test *testing.T) {
+	tests := map[byte]bool{
+		'a': true,
+		'm': true,
+		'Q': true,
+		'-': true,
+		'_': true,
+		'%': false,
+	}
+
+	for testChar, expected := range tests {
+		isLetter := isLetter(testChar)
+		if isLetter != expected {
+			test.Errorf("%v should have been %v, was %v", string(testChar), expected, isLetter)
+		}
+	}
+}
+
+func TestIsDigit(test *testing.T) {
+	tests := map[byte]bool{
+		'0': true,
+		'9': true,
+		'5': true,
+		'a': false,
+	}
+	for input, expectation := range tests {
+		actual := isDigit(input)
+		if actual != expectation {
+			test.Errorf("For input %v expected %v but got %v", input, expectation, actual)
+		}
+	}
+}
+
+func TestReadString(test *testing.T) {
+	// this is testing a method in a lexer, so it's assumed that the lexer
+	// will be at the beginning of a string when read (covered in other tests)
+	tests := map[string]string{
+		"air-brushed":       "air-brushed",
+		"snake_case":        "snake_case",
+		"camelCase":         "camelCase",
+		"string]":           "string",
+		"number123sandwich": "number",
+	}
+
+	for input, expected := range tests {
+		lexer := newLexer(input)
+		result := lexer.readString()
+		if result != expected {
+			test.Errorf("Parsing %s, expected %s got %s", input, expected, result)
+		}
+	}
+}
+
+func TestReadNumber(test *testing.T) {
+	tests := map[string]string{
+		"01234":      "01234",
+		"123456789]": "123456789",
+		"5678[901]":  "5678",
+	}
+	for input, expected := range tests {
+		lexer := newLexer(input)
+		actual := lexer.readNumber()
+		if actual != expected {
+			test.Errorf("Parsing %s, expected %s, got %s", input, expected, actual)
+		}
+	}
+}

--- a/badness/json_template/parser.go
+++ b/badness/json_template/parser.go
@@ -1,0 +1,220 @@
+package json_template
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// parse statements and construct a Template AST
+
+type Parser struct {
+	lexer     *Lexer
+	curToken  Token
+	peekToken Token
+}
+
+// NewParserWithString simplifies some of the work of creating a new parser
+func NewParserWithString(input string) *Parser {
+	lexer := newLexer(input)
+	return NewParser(lexer)
+}
+
+func NewParser(lexer *Lexer) *Parser {
+	parser := &Parser{lexer: lexer}
+
+	parser.nextToken()
+	parser.nextToken()
+
+	return parser
+}
+
+func (parser *Parser) nextToken() {
+	parser.curToken = parser.peekToken
+	parser.peekToken = parser.lexer.NextToken()
+}
+
+func (parser *Parser) ParseTemplate() (*Template, error) {
+
+	template := Template{make([]DataDeclaration, 0), make(map[string]DataDeclaration)}
+
+	for parser.curToken.Type != EOF {
+		if isDataType(parser.curToken.Literal) || parser.curToken.Type == KEY_NAME {
+
+			if parser.curToken.Type == KEY_NAME && parser.peekToken.Type == EQUAL {
+				// this defines a custom object
+				objectName := parser.curToken.Literal
+				parser.nextToken()
+				objectDeclaration, err := parser.parseObject()
+				if err != nil {
+					return nil, err
+				}
+				template.addDataDeclaration(objectDeclaration)
+				template.addCustomType(objectName, objectDeclaration)
+
+			} else {
+				dataDeclaration, err := parser.parseRawString()
+				if err != nil {
+					return nil, err
+				}
+				template.addDataDeclaration(dataDeclaration)
+			}
+
+		} else if parser.curToken.Type == LEFT_BRACKET {
+			dataDeclaration, err := parser.parseArray()
+			if err != nil {
+				return nil, err
+			}
+			template.addDataDeclaration(dataDeclaration)
+		} else if parser.curToken.Type == SEMICOLON {
+			parser.nextToken()
+			continue
+		} else {
+      return nil, fmt.Errorf("Unexpected character at position %d: %v", parser.lexer.position, parser.curToken)
+    }
+
+		if err := parser.assertPeekTypeOneOf([]TokenType{SEMICOLON, EOF}); err != nil {
+			return nil, err
+		}
+
+		parser.nextToken()
+	}
+	return &template, nil
+}
+
+// parses a string such as either "string" or "other key name"
+func (parser *Parser) parseRawString() (DataDeclaration, error) {
+	if isDataType(parser.curToken.Literal) {
+		return PrimitiveDataType{Literal: parser.curToken.Literal}, nil
+	} else {
+		return KeyNameDataType{Literal: parser.curToken.Literal}, nil
+	}
+}
+
+// parses an array. parser is currently at [
+func (parser *Parser) parseArray() (DataDeclaration, error) {
+	array := ArrayDataType{Length: 10000}
+	if err := parser.assertPeekTypeOneOf([]TokenType{KEY_NAME, STRING_DATA_TYPE, BOOL_DATA_TYPE, INT_DATA_TYPE, INCREMENT_DATA_TYPE}); err != nil {
+		return nil, err
+	}
+	parser.nextToken()
+
+	// figure out the nested data declaration
+	dataDeclaration, err := parser.parseRawString()
+	if err != nil {
+		return nil, err
+	}
+	array.NestedType = dataDeclaration
+
+	// make sure there's an ] coming up
+	if err = parser.assertPeekType(RIGHT_BRACKET); err != nil {
+		return nil, err
+	}
+
+	parser.nextToken()
+
+	// if there's a colon, we need to parse the length. Otherwise we can return
+	if parser.peekToken.Type == COLON {
+		parser.nextToken()
+
+		// check there's a number there
+		if err = parser.assertPeekType(NUMBER); err != nil {
+			return nil, err
+		}
+
+		parser.nextToken()
+		length, err := strconv.Atoi(parser.curToken.Literal)
+		if err != nil {
+			return nil, err
+		} else {
+			array.Length = length
+		}
+	}
+
+	return array, nil
+}
+
+// the parser is at an = when this is called
+func (parser *Parser) parseObject() (DataDeclaration, error) {
+	// format is key/value,key/value
+	if err := parser.assertPeekType(KEY_NAME); err != nil {
+		return nil, err
+	}
+
+	keyValues := make([]KeyValueDataType, 0)
+
+	parser.nextToken()
+
+	for parser.curToken.Type != EOF && parser.curToken.Type != SEMICOLON {
+		// each start of the loop should place the parser at a key token
+		key := parser.curToken.Literal
+
+		if err := parser.assertPeekType(SLASH); err != nil {
+			return nil, err
+		}
+
+		parser.nextToken()
+
+		if err := parser.assertPeekTypeOneOf([]TokenType{LEFT_BRACKET, KEY_NAME, STRING_DATA_TYPE, INT_DATA_TYPE, BOOL_DATA_TYPE, INCREMENT_DATA_TYPE}); err != nil {
+			return nil, err
+		}
+		parser.nextToken()
+
+		var valueData DataDeclaration
+		var parseErr error
+
+		switch parser.curToken.Type {
+		case LEFT_BRACKET:
+			valueData, parseErr = parser.parseArray()
+		case KEY_NAME, STRING_DATA_TYPE, INT_DATA_TYPE, BOOL_DATA_TYPE, INCREMENT_DATA_TYPE:
+			valueData, parseErr = parser.parseRawString()
+		default:
+			valueData = nil
+			parseErr = fmt.Errorf("Position %d: Unexpected token %s", parser.lexer.position, parser.curToken.Type)
+		}
+
+		if parseErr != nil {
+			return nil, parseErr
+		}
+
+		if err := parser.assertPeekTypeOneOf([]TokenType{COMMA, SEMICOLON, EOF}); err != nil {
+			return nil, err
+		}
+
+		keyValues = append(keyValues, KeyValueDataType{Key: key, Value: valueData})
+
+		// exit early if a semicolon/eof is upcoming
+		if parser.peekToken.Type == SEMICOLON || parser.peekToken.Type == EOF {
+			return ObjectDataType{Members: keyValues}, nil
+		}
+
+		if parser.peekToken.Type == COMMA {
+			// advance again to get past the comma
+			parser.nextToken()
+			if err := parser.assertPeekType(KEY_NAME); err != nil {
+				return nil, err
+			}
+			parser.nextToken()
+		}
+
+	}
+
+	return ObjectDataType{Members: keyValues}, nil
+}
+
+func (parser *Parser) assertPeekTypeOneOf(tokenTypes []TokenType) error {
+	for _, tokenType := range tokenTypes {
+		err := parser.assertPeekType(tokenType)
+		if err == nil {
+			// found a match
+			return nil
+		}
+	}
+	return fmt.Errorf("Expected one of %v at position %d, but was %s", tokenTypes, parser.lexer.position, parser.peekToken.Type)
+}
+
+func (parser *Parser) assertPeekType(tokenType TokenType) error {
+	if parser.peekToken.Type != tokenType {
+		return fmt.Errorf("Expected %s at %d, got %s", tokenType, parser.lexer.position, parser.peekToken.Type)
+	}
+	return nil
+}

--- a/badness/json_template/parser_test.go
+++ b/badness/json_template/parser_test.go
@@ -1,0 +1,134 @@
+package json_template
+
+import "testing"
+
+func TestPlainDataTypes(test *testing.T) {
+	input := "string;int;bool;increment"
+	lexer := newLexer(input)
+	parser := NewParser(lexer)
+
+	template, err := parser.ParseTemplate()
+	if err != nil {
+		test.Fatalf("Unexpected error, %v", err)
+	}
+
+	if len(template.Declarations) != 4 {
+		test.Errorf("Expected program of 4 but got %d", len(template.Declarations))
+	}
+}
+
+func TestAssertPeekToken(test *testing.T) {
+	input := "string;int"
+	lexer := newLexer(input)
+	parser := NewParser(lexer)
+
+	err := parser.assertPeekType(INT_DATA_TYPE)
+	if err == nil {
+		test.Errorf("Expected error but didn't get one")
+	}
+
+	err = parser.assertPeekType(SEMICOLON)
+	if err != nil {
+		test.Errorf("Unexpected error %v", err)
+	}
+}
+
+func TestAssertPeekOneOf(test *testing.T) {
+	input := "string;"
+	lexer := newLexer(input)
+	parser := NewParser(lexer)
+
+	err := parser.assertPeekTypeOneOf([]TokenType{INT_DATA_TYPE, EQUAL})
+	if err == nil {
+		test.Errorf("Expected error but didn't get one")
+	}
+
+	err = parser.assertPeekTypeOneOf([]TokenType{SEMICOLON, EOF})
+	if err != nil {
+		test.Errorf("Unexpected error %v", err)
+	}
+}
+
+// verify the TokenLiteral output for different simple parse strings
+type tokenLiteralTest struct {
+	input    string
+	expected string
+}
+
+func TestTokenLiterals(test *testing.T) {
+	tests := []tokenLiteralTest{
+		{"string", "string"},
+		{"int", "int"},
+		{"bool", "bool"},
+		{"increment", "increment"},
+		{"[string]", "[string]:10000"},
+		{"[string]:100", "[string]:100"},
+		{"book=title/string", "{title: string}"},
+		{"book=title/string,pages/[string]", "{title: string, pages: [string]:10000}"},
+	}
+
+	for testNumber, testCase := range tests {
+		lexer := newLexer(testCase.input)
+		parser := NewParser(lexer)
+		template, err := parser.ParseTemplate()
+		if err != nil {
+			test.Fatalf("Test case %d: Unexpected error in parsing: %v", testNumber, err)
+		}
+
+		if len(template.Declarations) == 0 {
+			test.Errorf("Test case %d: Template is empty")
+		} else {
+			output := template.Declarations[0].TokenLiteral()
+			if testCase.expected != output {
+				test.Errorf("Test case %d: Expected %s but got %s", testNumber, testCase.expected, output)
+			}
+		}
+	}
+}
+
+func TestParseMulti(test *testing.T) {
+	tests := map[string][]string{
+		"book;book=title/string":                     []string{"book", "{title: string}"},
+		"book;book=pages/[page]:1;page=text/string":  []string{"book", "{pages: [page]:1}", "{text: string}"},
+		"book;book=pages/[page]:1;;page=text/string": []string{"book", "{pages: [page]:1}", "{text: string}"},
+	}
+
+	for input, expected := range tests {
+		parser := NewParserWithString(input)
+		template, err := parser.ParseTemplate()
+		if err != nil {
+			test.Fatalf("Unexpected error in parsing %s: %v", input, err)
+		}
+
+		for index, expectedToken := range expected {
+			actual := template.Declarations[index].TokenLiteral()
+			if actual != expectedToken {
+				test.Errorf("For input %s, expected %s in position %d but got %s", input, expectedToken, index, actual)
+			}
+		}
+
+	}
+}
+
+func TestParseErrors(test *testing.T) {
+	// all of these should generate errors
+	tests := []string{
+		"string&",
+		"[123]",
+		"[string]:gh",
+		"[123",
+		"book=string",
+		"book=title",
+		"book=title/string/isbn/string",
+		"book=pages/[page]:100;%;page=text/string",
+	}
+
+	for testNumber, testCase := range tests {
+		lexer := newLexer(testCase)
+		parser := NewParser(lexer)
+		_, err := parser.ParseTemplate()
+		if err == nil {
+			test.Errorf("Test %d (%s) should have produced an error but did not", testNumber, testCase)
+		}
+	}
+}

--- a/badness/json_template/tokens.go
+++ b/badness/json_template/tokens.go
@@ -1,0 +1,63 @@
+package json_template
+
+// json_template provides a small parser for converting a program into a JSON template
+// that can in turn be used to create a string of json generators for writing back
+// a response that meets the template
+//
+// Examples:
+// [string]:1000 will create an array of 1000 strings
+// [book]:1000;book=title/string,author/string will create an array of book objects
+// title/string,author/string,chapters/[string]:6 will return an object with a title and an author and a 6-item array of strings
+
+type TokenType string
+
+type Token struct {
+	Type    TokenType
+	Literal string
+}
+
+const (
+	ILLEGAL       = "ILLEGAL"
+	EOF           = "EOF"
+	SLASH         = "/"
+	LEFT_BRACKET  = "["
+	RIGHT_BRACKET = "]"
+
+	// data types
+	STRING_DATA_TYPE    = "STRING"
+	INT_DATA_TYPE       = "INT"
+	INCREMENT_DATA_TYPE = "INCREMENT"
+	BOOL_DATA_TYPE      = "BOOL"
+
+	// keys or sizes
+	KEY_NAME = "KEY_NAME"
+	NUMBER   = "NUMBER"
+
+	EQUAL = "="
+	COLON = ":"
+
+	COMMA     = ","
+	SEMICOLON = ";"
+)
+
+var dataTypes = map[string]TokenType{
+	"string":    STRING_DATA_TYPE,
+	"int":       INT_DATA_TYPE,
+	"increment": INCREMENT_DATA_TYPE,
+	"bool":      BOOL_DATA_TYPE,
+}
+
+// stringToToken decides if the passed-string is a known datatype or not
+// and returns the appropriate token
+func stringToToken(input string) TokenType {
+	if isDataType(input) {
+		return dataTypes[input]
+	}
+	return KEY_NAME
+}
+
+// determines if the given TokenType is a data type
+func isDataType(input string) bool {
+	_, found := dataTypes[input]
+	return found
+}

--- a/badness/json_template/tokens_test.go
+++ b/badness/json_template/tokens_test.go
@@ -1,0 +1,39 @@
+package json_template
+
+import (
+	"testing"
+)
+
+func TestStringToToken(test *testing.T) {
+	tests := map[string]TokenType{
+		"string":    "STRING",
+		"int":       "INT",
+		"bool":      "BOOL",
+		"increment": "INCREMENT",
+		"sniffle":   "KEY_NAME",
+	}
+
+	for input, expected := range tests {
+		token := stringToToken(input)
+		if token != expected {
+			test.Errorf("Test for %s: expected %s, was %s", input, expected, token)
+		}
+	}
+}
+
+func TestIsDataType(test *testing.T) {
+	tests := map[string]bool{
+		"string":    true,
+		"int":       true,
+		"bool":      true,
+		"increment": true,
+		"sniffle":   false,
+	}
+
+	for input, expected := range tests {
+		actual := isDataType(input)
+		if expected != actual {
+			test.Errorf("Test for %s: expected %v, got %v", input, expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
This adds a small language for defining JSON that is then filled randomly. This is to allow clients to test the scenario where a server sends back many more records than the client is expecting (perhaps because of a server bug). Many application writers bind JSON results from HTTP to particular structures in this language, so this allows that binding to still be valid while also generating many records.