### PR TITLE
Add an admin port for command functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ Response's Content-Length is shorter than content.
     X-Return-Header: Content-Length: 1000
     X-Generate-Random: 6000
     
+Administration
+-------------------------
+The server also has an admin port that you can use for certain global operations
+
+  * /headers: 
+    * POST all the headers in the request will be used as defaults that are merged into incoming requests on the main port
+    * GET will give you the current set of default headers as headers in the response
+    * DELETE will clear out any defaults
+    
 Development
 -----------
 bad-server works by creating an ordered pipeline of functions that all take http.ResponseWriter

--- a/adminserver/admin_server.go
+++ b/adminserver/admin_server.go
@@ -1,0 +1,98 @@
+// admin_server handles administrative functions for bad server
+package adminserver
+
+import (
+	"net/http"
+	"strings"
+)
+
+type command string
+
+const update command = "update"
+const merge command = "merge"
+const get command = "get"
+const clear command = "clear"
+
+type adminMessage struct {
+	messageType command
+}
+
+type headerMessage struct {
+	headers       http.Header
+	returnChannel chan http.Header
+	adminMessage
+}
+
+var headerCommands = make(chan headerMessage)
+var defaultHeaders = make(map[string][]string)
+
+func init() {
+	go processHeaderCommands()
+}
+
+func processHeaderCommands() {
+	for command := range headerCommands {
+		switch command.messageType {
+		case update:
+			defaultHeaders = command.headers
+			command.returnChannel <- defaultHeaders
+		case get:
+			command.returnChannel <- defaultHeaders
+		default:
+			command.returnChannel <- make(map[string][]string)
+		}
+	}
+}
+
+func RouteAdminCall(response http.ResponseWriter, request *http.Request) {
+	if strings.HasPrefix(request.URL.Path, "/headers") {
+		switch request.Method {
+		case "GET":
+			returnDefaultHeaders(response, request)
+		case "POST":
+			updateDefaultHeaders(response, request)
+		case "DELETE":
+			clearDefaultHeaders(response, request)
+		default:
+			response.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+var emptyHeaders = make(map[string][]string)
+
+func GetCurrentHeaders() map[string][]string {
+	returnChan := make(chan http.Header, 1)
+	defer close(returnChan)
+	headerCommands <- headerMessage{emptyHeaders, returnChan, adminMessage{get}}
+
+	returnHeaders := <-returnChan
+
+	return returnHeaders
+}
+
+func updateDefaultHeaders(response http.ResponseWriter, request *http.Request) {
+	sendHeaderCommand(response, request, update)
+}
+
+func returnDefaultHeaders(response http.ResponseWriter, request *http.Request) {
+	sendHeaderCommand(response, request, get)
+}
+
+func clearDefaultHeaders(response http.ResponseWriter, request *http.Request) {
+	request.Header = make(map[string][]string)
+	updateDefaultHeaders(response, request)
+}
+
+func sendHeaderCommand(response http.ResponseWriter, request *http.Request, messageType command) {
+	returnChan := make(chan http.Header, 1)
+	defer close(returnChan)
+
+	headerCommands <- headerMessage{request.Header, returnChan, adminMessage{messageType}}
+
+	headerResponse := <-returnChan
+
+	for key, value := range headerResponse {
+		response.Header()[key] = value
+	}
+}

--- a/adminserver/admin_server_test.go
+++ b/adminserver/admin_server_test.go
@@ -1,0 +1,62 @@
+package adminserver
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestUpdateHeaders(test *testing.T) {
+	resetDefaultHeaders()
+
+	request := httptest.NewRequest("POST", "/headers", nil)
+	recorder := httptest.NewRecorder()
+
+	setHeaders := map[string][]string{
+		"X-Generate-Random": []string{"1000"},
+		"X-Random-Json":     []string{"response_template=[returnObject]:100;returnObject=author/authorObject", "authorObject=id/int,name/string"},
+	}
+
+	request.Header = setHeaders
+	updateDefaultHeaders(recorder, request)
+	response := recorder.Result()
+
+	for header, headerValue := range setHeaders {
+		responseValue, found := response.Header[header]
+		if !found {
+			test.Fatalf("key %s should have been in response but was not", header)
+		}
+
+		if len(responseValue) != len(headerValue) {
+			test.Fatalf("value for %s should be the same length as test value. expected %d was %d", header, len(headerValue), len(responseValue))
+		}
+	}
+}
+
+func TestGetDefaultHeaders(test *testing.T) {
+	resetDefaultHeaders()
+	request := httptest.NewRequest("POST", "/headers", nil)
+	recorder := httptest.NewRecorder()
+	setHeaders := map[string][]string{
+		"X-Generate-Random": []string{"1000"},
+		"X-Random-Json":     []string{"response_template=[returnObject]:100;returnObject=author/authorObjec;authorObject=id/int,name/string"},
+	}
+	request.Header = setHeaders
+	updateDefaultHeaders(recorder, request)
+
+	getHeaders := GetCurrentHeaders()
+	for testHeader, expectedValue := range setHeaders {
+		if actualValue, present := getHeaders[testHeader]; !present {
+			test.Fatalf("Expected header %s in response. Was not present.", testHeader)
+
+			if len(expectedValue) != len(actualValue) {
+				test.Fatalf("Values for %s are different lengths. Expected %d got %d", testHeader, len(expectedValue), len(actualValue))
+			}
+		}
+	}
+}
+
+func resetDefaultHeaders() {
+	request := httptest.NewRequest("POST", "/headers", nil)
+	response := httptest.NewRecorder()
+	clearDefaultHeaders(response, request)
+}

--- a/main.go
+++ b/main.go
@@ -6,27 +6,57 @@ import (
 	"log"
 	"net/http"
 
+	"bad-server/adminserver"
 	"bad-server/badness"
 )
 
 var port int
+var adminPort int
+
+type mainHandler struct{}
+
+func (mainHandler) ServeHTTP(response http.ResponseWriter, request *http.Request) {
+	mergeDefaultHeadersToRequest(request)
+	pipeline := badness.GetResponsePipeline(request)
+	for _, responseHandler := range pipeline {
+		responseHandler(response)
+	}
+}
+
+type adminHandler struct{}
+
+func (adminHandler) ServeHTTP(response http.ResponseWriter, request *http.Request) {
+	mergeDefaultHeadersToRequest(request)
+	adminserver.RouteAdminCall(response, request)
+	defer request.Body.Close()
+}
 
 func init() {
 	flag.IntVar(&port, "port", 7865, "The port to listen on")
+	flag.IntVar(&adminPort, "adminPort", 7866, "The port for admin functions")
 }
 
 func main() {
 	flag.Parse()
 
-	http.HandleFunc("/", handleBadServerRequest)
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), nil))
+	// use different server multiplexers for each server, to avoid path conflicts
+	mainServerMux := http.NewServeMux()
+	mainServerMux.Handle("/", &mainHandler{})
+	go func() {
+		log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), mainServerMux))
+	}()
+
+	adminServerMux := http.NewServeMux()
+	adminServerMux.Handle("/", &adminHandler{})
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", adminPort), adminServerMux))
 }
 
-// handleBadServerRequest will delegate to appropriate other handlers to generate
-// the appropriate bad response
-func handleBadServerRequest(response http.ResponseWriter, request *http.Request) {
-	pipeline := badness.GetResponsePipeline(request)
-	for _, responseHandler := range pipeline {
-		responseHandler(response)
+func mergeDefaultHeadersToRequest(request *http.Request) {
+	defaultHeaders := adminserver.GetCurrentHeaders()
+
+	for key, value := range defaultHeaders {
+		if _, found := request.Header[key]; !found {
+			request.Header[key] = value
+		}
 	}
 }


### PR DESCRIPTION
This also wires up the first command, which can be used to set and get
default headers that will be used for any request that doesn't have those
headers.