### PR TITLE
Add an "enum" capability to json generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ header in a request. Exceptions to this include:
   * X-Response-Code-Histogram
   * X-Return-Header
   * X-Random-Json
-  
+
 Headers
 -------
 X-Response-Code-Histogram: send a status code based on an input histogram
@@ -29,37 +29,39 @@ X-Pause-Before-Response-Start: wait the specified amount of time before sending 
 
   * X-Pause-Before-Response-Start: 300 => wait 300ms before responding
   * X-Pause-Before-Response-Start: 1m => wait one minute before responding (uses [golang duration syntax](https://golang.org/pkg/time/#ParseDuration))
-  
+
 X-Add-Noise: randomly mutate bytes based on randomness percentage
 
   * X-Add-Noise: 3.0 => up to 3% of bytes will be randomly mutated
-  
+
 X-Return-Header: set the given header to the given value. Multiple instances of this header will get collated
 
   * X-Return-Header: Content-Type: application/json => response will have a Content-Type: application/json header
-  
+
 X-Generate-Random: generate random data for the given number of bytes
 
   * X-Generate-Random: 100 => 100 random bytes are returned
-  
+
 X-Random-Delays: randomly delay sending chunks of data
 
   * X-Random-Delays: 100 => chunks of data will be sent with up to 100ms delays sprinkled in
   * X-Random-Delays: 10ns=70.0;100ms => chunks of data will be sent with up to 10ns delays 70% of the time, and up to 100ms for 30% of the time
-  
+
 X-Proxy-To-Host: send the exact same request to the specified host and feed the response to the client.
-Note that other header and request generators will be ignored if this is set. 
+Note that other header and request generators will be ignored if this is set.
 However, headers that affect the transmission will still be used.
 
   * X-Proxy-To-Host: http://www.google.com => send the same url that triggered this to www.google.com and retransmit the response
-    
+
 X-Random-Json: send random but structured JSON to the client to simulate unexpectedly large payloads
 
   * X-Random-Json: response_template=[string]:100 => sends an array of 100 strings
   * X-Random-Json: response_template=[returnObject]:100;returnObject=id/int,name/string => send 100 objects that have a numeric ID field and a string name field
   * X-Random-Json: response_template=[returnObject]:100;returnObject=author/authorObject;authorObject=id/int,name/string => send 100 records where each one will have an author key that will in turn be an object with an id and name
   * X-Random-Json: response_template=titlesContainer;titlesContainer=titles/[string]:100 => return an object that contains a field named titles that is 100 random strings
-  
+  * X-Random-Json: response_template=[string|blue,red,yellow] => Return a string array where the values will be one of "blue," "red," or "yellow"
+  * X-Random-Json: response_template=returnObject;returnObject=commandType/int|1,2,3 => Return an object that has a commandType field that is either 1, 2, or 3
+
 More on X-Random-Json
 ---------------------
 Here are the primitive data types you can use for a field:
@@ -70,9 +72,9 @@ Here are the primitive data types you can use for a field:
   * bool
   * increment - a numeric field that increases in each record
   * <object name> - another object defined within the same header
-  
-Each of these can have [] placed around them to create an array of that type. Arrays are 10,000 items unless you specify a length with ":N" after the array. The "root" item must be identified with "response_template="
-  
+
+Each of these can have [] placed around them to create an array of that type. Primitive types (string, int, float) can have an enum of appropriate values. Arrays are 10,000 items unless you specify a length with ":N" after the array. The "root" item must be identified with "response_template="
+
 Complex Examples
 ----------------
 Combining headers lets you create other types of unexpected behaviors.
@@ -81,26 +83,26 @@ Response's content-type does not match content.
 
     X-Return-Header: Content-Type: application/json
     X-Generate-Random: 600
-    
+
 Response's Content-Length is longer than content.
 
     X-Return-Header: Content-Length: 6000
     X-Generate-Random: 1000
-    
+
 Response's Content-Length is shorter than content.
 
     X-Return-Header: Content-Length: 1000
     X-Generate-Random: 6000
-    
+
 Administration
 -------------------------
 The server also has an admin port that you can use for certain global operations
 
-  * /headers: 
+  * /headers:
     * POST all the headers in the request will be used as defaults that are merged into incoming requests on the main port
     * GET will give you the current set of default headers as headers in the response
     * DELETE will clear out any defaults
-    
+
 Development
 -----------
 bad-server works by creating an ordered pipeline of functions that all take http.ResponseWriter
@@ -109,7 +111,7 @@ pointers. Functions are placed into the pipeline in this order:
   1. status_code generator
   2. header generators
   3. response body generator wrapped in response affectors
-  
+
 Only one status code generator and response body generator will be derived
 from the headers sent to bad-server. If you include multiple response body
 generators in your header, they will be processed in this order (from `general.go`)
@@ -118,6 +120,3 @@ generators in your header, they will be processed in this order (from `general.g
     2. X-Generate-Random
     3. X-Random-Json
     4. empty string
-  
-  
-  

--- a/badness/json_generator_test.go
+++ b/badness/json_generator_test.go
@@ -26,6 +26,8 @@ func TestJsonElementGeneration(test *testing.T) {
 		jsonElementExpectation{newArrayGenerator(2, newIncrementGenerator(1)), "\\[1,2\\]"},
 		jsonElementExpectation{newObjectGenerator([]keyValueGenerator{newKeyValueGenerator("key1", newIntGenerator(100)).(keyValueGenerator), newKeyValueGenerator("key2", newFixedStringGenerator("value")).(keyValueGenerator)}), "\\{\"key1\":[0-9]+,\"key2\":\"value\"}"},
 		jsonElementExpectation{newErrorGenerator("no-error"), "\\{\"error\":\"no-error\"\\}"},
+		jsonElementExpectation{newIntFromSetGenerator([]int{1,2,3}), "1|2|3"},
+		jsonElementExpectation{newStringFromSetGenerator([]string{"a","b","c"}), "a|b|c"},
 	}
 
 	for index, expect := range expects {

--- a/badness/json_template/ast.go
+++ b/badness/json_template/ast.go
@@ -2,6 +2,8 @@ package json_template
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 )
 
 // ast for json_template code. A template is defined by a series of
@@ -67,6 +69,43 @@ type KeyValueDataType struct {
 
 func (keyValue KeyValueDataType) TokenLiteral() string {
 	return fmt.Sprintf("%s: %s", keyValue.Key, keyValue.Value.TokenLiteral())
+}
+
+type EnumStringDataType struct {
+	DataDeclaration
+	Values []string
+}
+
+func (enumString EnumStringDataType) TokenLiteral() string {
+	return fmt.Sprintf("(%s)", strings.Join(enumString.Values, "|"))
+}
+
+type EnumIntDataType struct {
+	DataDeclaration
+	Values []int
+}
+
+func (enumInt EnumIntDataType) TokenLiteral() string {
+	stringValues := make([]string, 0, len(enumInt.Values))
+	for _, intValue := range enumInt.Values {
+		stringValues = append(stringValues, strconv.Itoa(intValue))
+	}
+
+	return fmt.Sprintf("(%s)", strings.Join(stringValues, "|"))
+}
+
+type EnumFloatDataType struct {
+	DataDeclaration
+	Values []float64
+}
+
+func (enumFloat EnumFloatDataType) TokenLiteral() string {
+	stringValues := make([]string, 0, len(enumFloat.Values))
+	for _, floatValue := range enumFloat.Values {
+		stringValues = append(stringValues, fmt.Sprintf("%v", floatValue))
+	}
+
+	return fmt.Sprintf("(%s)", strings.Join(stringValues, "|"))
 }
 
 type ObjectDataType struct {

--- a/badness/json_template/lexer.go
+++ b/badness/json_template/lexer.go
@@ -43,6 +43,8 @@ func (lexer *Lexer) NextToken() Token {
 		token = newToken(COLON, lexer.ch)
 	case ',':
 		token = newToken(COMMA, lexer.ch)
+	case '|':
+		token = newToken(PIPE, lexer.ch)
 	default:
 		if isLetter(lexer.ch) {
 			fullString := lexer.readString()

--- a/badness/json_template/lexer_test.go
+++ b/badness/json_template/lexer_test.go
@@ -10,7 +10,7 @@ type tokenExpect struct {
 }
 
 func TestNextToken(test *testing.T) {
-	input := "=:,/[];string;bookcase;increment;int;bool;1234"
+	input := "=:,/[];string;bookcase;increment;int;bool;1234|"
 
 	expects := []tokenExpect{
 		{EQUAL, "="},
@@ -31,6 +31,7 @@ func TestNextToken(test *testing.T) {
 		{BOOL_DATA_TYPE, "bool"},
 		{SEMICOLON, ";"},
 		{NUMBER, "1234"},
+		{PIPE, "|"},
 	}
 	lexer := newLexer(input)
 

--- a/badness/json_template/parser_test.go
+++ b/badness/json_template/parser_test.go
@@ -65,6 +65,8 @@ func TestTokenLiterals(test *testing.T) {
 		{"[string]:100", "[string]:100"},
 		{"book=title/string", "{title: string}"},
 		{"book=title/string,pages/[string]", "{title: string, pages: [string]:10000}"},
+		{"[string|a,b,c]", "[(a|b|c)]:10000"},
+		{"int|1,2,3", "(1|2|3)"},
 	}
 
 	for testNumber, testCase := range tests {
@@ -76,7 +78,7 @@ func TestTokenLiterals(test *testing.T) {
 		}
 
 		if len(template.Declarations) == 0 {
-			test.Errorf("Test case %d: Template is empty")
+			test.Errorf("Test case %d: Template is empty", testNumber)
 		} else {
 			output := template.Declarations[0].TokenLiteral()
 			if testCase.expected != output {
@@ -121,6 +123,8 @@ func TestParseErrors(test *testing.T) {
 		"book=title",
 		"book=title/string/isbn/string",
 		"book=pages/[page]:100;%;page=text/string",
+		"int|1,a,3",
+		"int|",
 	}
 
 	for testNumber, testCase := range tests {
@@ -129,6 +133,22 @@ func TestParseErrors(test *testing.T) {
 		_, err := parser.ParseTemplate()
 		if err == nil {
 			test.Errorf("Test %d (%s) should have produced an error but did not", testNumber, testCase)
+		}
+	}
+}
+
+func TestExtractEnumValues(test *testing.T) {
+	testString := "|1,a,c"
+	parser := NewParserWithString(testString)
+	values := parser.extractEnumData()
+	if len(values) != 3 {
+		test.Errorf("Expected 3 strings but got %v", len(values))
+	}
+
+	expectedValues := []string{"1", "a", "c"}
+	for index, extractedString := range values {
+		if expectedValues[index] != extractedString {
+			test.Errorf("Expected string %v but got %v", expectedValues[index], extractedString)
 		}
 	}
 }

--- a/badness/json_template/tokens.go
+++ b/badness/json_template/tokens.go
@@ -38,6 +38,8 @@ const (
 
 	COMMA     = ","
 	SEMICOLON = ";"
+
+	PIPE = "|"
 )
 
 var dataTypes = map[string]TokenType{


### PR DESCRIPTION
"string|q,z,x" will ensure that the result is one of q,z, or x
"[int|1,2,3] will return an array of ints where each one is 1,2, or 3